### PR TITLE
🌐 Internationalizing

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,8 +2,8 @@
   <code_scheme name="Project" version="173">
     <option name="OTHER_INDENT_OPTIONS">
       <value>
-        <option name="INDENT_SIZE" value="2" />
-        <option name="TAB_SIZE" value="2" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+        <option name="SMART_TABS" value="true" />
       </value>
     </option>
     <codeStyleSettings language="Dart">

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,9 @@ extract-arb:
 
 generate-intl:
 	flutter pub run intl_translation:generate_from_arb --output-dir=lib\l10n --no-use-deferred-loading lib\zephyr_localization.dart lib\l10n\intl_en.arb lib\l10n\intl_fr.arb
+
+lint:
+	dartfmt -n --set-exit-if-changed -l 120 .
+
+fix-lint:
+	dartfmt -w -l 120 .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ extract-arb:
 	flutter pub run intl_translation:extract_to_arb --output-dir=lib\l10n lib\zephyr_localization.dart
 
 generate-intl:
-	flutter pub run intl_translation:generate_from_arb --output-dir=lib\l10n --no-use-deferred-loading lib\zephyr_localization.dart lib\l10n\intl_en.arb lib\l10n\intl_fr.arb
+	flutter pub run intl_translation:generate_from_arb --output-dir=lib\l10n --no-use-deferred-loading lib\zephyr_localization.dart lib\l10n\intl_en.arb lib\l10n\intl_fr.arb lib\l10n\intl_es.arb
 
 lint:
 	dartfmt -n --set-exit-if-changed -l 120 .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+extract-arb:
+	flutter pub run intl_translation:extract_to_arb --output-dir=lib\l10n lib\zephyr_localization.dart
+
+generate-intl:
+	flutter pub run intl_translation:generate_from_arb --output-dir=lib\l10n --no-use-deferred-loading lib\zephyr_localization.dart lib\l10n\intl_en.arb lib\l10n\intl_fr.arb

--- a/README.md
+++ b/README.md
@@ -10,4 +10,57 @@ Zéphyr is a dictionary for LSF.
 
 ## Demo
 
-![Zéphyr demo](https://i.imgur.com/JWgqfWL.gif)
+![Zéphyr demo][zéphyr-demo]
+
+## Getting Started
+
+The following instructions will get you a copy of the source code, and help you execute it.
+
+### Requirements
+
+This project requires [Flutter][flutter-install], SDK version: minimum
+2.3.0.
+
+### Installation
+
+The first thing to do is to download the project, either by [downloading the ZIP file][zephyr-zip]
+and extract it somewhere in your machine, or by cloning the project with
+`git clone https://github.com/Cynnexis/zephyr.git`. The following steps will assume that the current
+directory is the project root.
+
+1. `flutter create --no-overwrite .`
+2. `flutter pub get`
+3. `flutter analyze`
+4. `flutter test`
+5. `flutter run`
+
+The app should be running now.
+
+## Build With
+
+* [Dart][dart]
+* [Flutter][flutter]
+* [Android Studio][android-studio]
+
+## Contributing
+
+Contribution is not permitted yet, because one of the goal of the project is for me to learn how to
+develop mobile app using Flutter SDK and the Dart language.
+
+## Author
+
+* **Valentin Berger ([Cynnexis][cynnexis]):** developer
+
+## License
+
+This project is under the GNU General Public License. Please see the [LICENSE.txt][license] file
+for more detail (it's a really fascinating story written in there!)
+
+[zéphyr-demo]: https://i.imgur.com/JWgqfWL.gif
+[flutter-install]: https://flutter.dev/docs/get-started/install
+[zephyr-zip]: https://github.com/Cynnexis/zephyr/archive/master.zip
+[flutter]: https://flutter.dev/
+[dart]: https://dart.dev/
+[android-studio]: https://developer.android.com/studio
+[cynnexis]: https://github.com/Cynnexis
+[license]: https://github.com/Cynnexis/zephyr/blob/master/LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ develop mobile app using Flutter SDK and the Dart language.
 This project is under the GNU General Public License. Please see the [LICENSE.txt][license] file
 for more detail (it's a really fascinating story written in there!)
 
-[zéphyr-demo]: https://i.imgur.com/JWgqfWL.gif
+[zéphyr-demo]: https://i.imgur.com/mvmbIwa.gif
 [flutter-install]: https://flutter.dev/docs/get-started/install
 [zephyr-zip]: https://github.com/Cynnexis/zephyr/archive/master.zip
 [flutter]: https://flutter.dev/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - extension-methods

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,24 @@
+{
+  "@@locale": "en",
+  "@@last_modified": "2020-06-14T19:32:36.910284",
+  "appName": "Zéphyr",
+  "@appName": {
+    "description": "The application name.",
+    "type": "text"
+  },
+  "searchSign": "Search a sign",
+  "@searchSign": {
+    "description": "Indicates what the user must put in the search field.",
+    "type": "text"
+  },
+  "loading": "Loading{suffix}",
+  "@loading": {
+    "description": "Loading text.",
+    "type": "text"
+  },
+  "resultsFor": "{numResults,plural, =0{No results for \"{keywords}\"}=1{Result for \"{keywords}\"}other{Results for \"{keywords}\"}}",
+  "@resultsFor": {
+    "description": "Title for the results page.",
+    "type": "text"
+  }
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "en",
-  "@@last_modified": "2020-06-14T19:32:36.910284",
+  "@@last_modified": "2020-06-15T16:37:22.758421",
   "appName": "Zéphyr",
   "@appName": {
     "description": "The application name.",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,22 +1,22 @@
 {
-  "@@locale": "fr",
+  "@@locale": "es",
   "@@last_modified": "2020-06-15T16:37:22.758421",
   "appName": "Zéphyr",
   "@appName": {
     "description": "The application name.",
     "type": "text"
   },
-  "searchSign": "Rechercher un signe",
+  "searchSign": "Busca una señal",
   "@searchSign": {
     "description": "Indicates what the user must put in the search field.",
     "type": "text"
   },
-  "loading": "Chargement{suffix}",
+  "loading": "Cargando{suffix}",
   "@loading": {
     "description": "Loading text.",
     "type": "text"
   },
-  "resultsFor": "{numResults,plural, =0{Aucun résultats pour \"{keywords}\"}=1{Résultat pour \"{keywords}\"}other{Résultats pour \"{keywords}\"}}",
+  "resultsFor": "{numResults,plural, =0{No hay resultados para \"{keywords}\"}=1{Resultado para \"{keywords}\"}other{Resultados para \"{keywords}\"}}",
   "@resultsFor": {
     "description": "Title for the results page.",
     "type": "text"

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,0 +1,24 @@
+{
+  "@@locale": "fr",
+  "@@last_modified": "2020-06-14T19:32:36.910284",
+  "appName": "Zéphyr",
+  "@appName": {
+    "description": "The application name.",
+    "type": "text"
+  },
+  "searchSign": "Rechercher un signe",
+  "@searchSign": {
+    "description": "Indicates what the user must put in the search field.",
+    "type": "text"
+  },
+  "loading": "Chargement{suffix}",
+  "@loading": {
+    "description": "Loading text.",
+    "type": "text"
+  },
+  "resultsFor": "{numResults,plural, =0{Aucun résultats pour \"{keywords}\"}=1{Résultat pour \"{keywords}\"}other{Résultats pour \"{keywords}\"}}",
+  "@resultsFor": {
+    "description": "Title for the results page.",
+    "type": "text"
+  }
+}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,0 +1,38 @@
+{
+  "@@last_modified": "2020-06-15T16:37:22.758421",
+  "appName": "Zéphyr",
+  "@appName": {
+    "description": "The application name.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "searchSign": "Search a sign",
+  "@searchSign": {
+    "description": "Indicates what the user must put in the search field.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "loading": "Loading{suffix}",
+  "@loading": {
+    "description": "Loading text.",
+    "type": "text",
+    "placeholders": {
+      "suffix": {
+        "example": " program..."
+      }
+    }
+  },
+  "resultsFor": "{numResults,plural, =0{No results for \"{keywords}\"}=1{Result for \"{keywords}\"}other{Results for \"{keywords}\"}}",
+  "@resultsFor": {
+    "description": "Title for the results page.",
+    "type": "text",
+    "placeholders": {
+      "numResults": {
+        "example": 8
+      },
+      "keywords": {
+        "example": "minute"
+      }
+    }
+  }
+}

--- a/lib/l10n/messages_all.dart
+++ b/lib/l10n/messages_all.dart
@@ -1,0 +1,67 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_en.dart' as messages_en;
+import 'messages_fr.dart' as messages_fr;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'en': () => new Future.value(null),
+  'fr': () => new Future.value(null),
+};
+
+MessageLookupByLibrary _findExact(String localeName) {
+  switch (localeName) {
+    case 'en':
+      return messages_en.messages;
+    case 'fr':
+      return messages_fr.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) async {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
+  if (availableLocale == null) {
+    return new Future.value(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new Future.value(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/lib/l10n/messages_all.dart
+++ b/lib/l10n/messages_all.dart
@@ -17,11 +17,13 @@ import 'package:intl/src/intl_helpers.dart';
 
 import 'messages_en.dart' as messages_en;
 import 'messages_fr.dart' as messages_fr;
+import 'messages_es.dart' as messages_es;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
   'en': () => new Future.value(null),
   'fr': () => new Future.value(null),
+  'es': () => new Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(String localeName) {
@@ -30,6 +32,8 @@ MessageLookupByLibrary _findExact(String localeName) {
       return messages_en.messages;
     case 'fr':
       return messages_fr.messages;
+    case 'es':
+      return messages_es.messages;
     default:
       return null;
   }

--- a/lib/l10n/messages_all.dart
+++ b/lib/l10n/messages_all.dart
@@ -37,10 +37,8 @@ MessageLookupByLibrary _findExact(String localeName) {
 
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
-  var availableLocale = Intl.verifiedLocale(
-    localeName,
-    (locale) => _deferredLibraries[locale] != null,
-    onFailure: (_) => null);
+  var availableLocale =
+      Intl.verifiedLocale(localeName, (locale) => _deferredLibraries[locale] != null, onFailure: (_) => null);
   if (availableLocale == null) {
     return new Future.value(false);
   }
@@ -60,8 +58,7 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
-  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
-      onFailure: (_) => null);
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -21,13 +21,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m0(suffix) => "Loading${suffix}";
 
-  static m1(numResults, keywords) => "${Intl.plural(numResults, zero: 'No results for \"${keywords}\"', one: 'Result for \"${keywords}\"', other: 'Results for \"${keywords}\"')}";
+  static m1(numResults, keywords) =>
+      "${Intl.plural(numResults, zero: 'No results for \"${keywords}\"', one: 'Result for \"${keywords}\"', other: 'Results for \"${keywords}\"')}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
-    "loading" : m0,
-    "resultsFor" : m1,
-    "searchSign" : MessageLookupByLibrary.simpleMessage("Search a sign")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "loading": m0,
+        "resultsFor": m1,
+        "searchSign": MessageLookupByLibrary.simpleMessage("Search a sign")
+      };
 }

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -1,0 +1,33 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  static m0(suffix) => "Loading${suffix}";
+
+  static m1(numResults, keywords) => "${Intl.plural(numResults, zero: 'No results for \"${keywords}\"', one: 'Result for \"${keywords}\"', other: 'Results for \"${keywords}\"')}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
+    "loading" : m0,
+    "resultsFor" : m1,
+    "searchSign" : MessageLookupByLibrary.simpleMessage("Search a sign")
+  };
+}

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -1,0 +1,34 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a es locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'es';
+
+  static m0(suffix) => "Cargando${suffix}";
+
+  static m1(numResults, keywords) =>
+      "${Intl.plural(numResults, zero: 'No hay resultados para \"${keywords}\"', one: 'Resultado para \"${keywords}\"', other: 'Resultados para \"${keywords}\"')}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function>{
+        "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "loading": m0,
+        "resultsFor": m1,
+        "searchSign": MessageLookupByLibrary.simpleMessage("Busca una señal")
+      };
+}

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -1,0 +1,33 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a fr locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'fr';
+
+  static m0(suffix) => "Chargement${suffix}";
+
+  static m1(numResults, keywords) => "${Intl.plural(numResults, zero: 'Aucun résultats pour \"${keywords}\"', one: 'Résultat pour \"${keywords}\"', other: 'Résultats pour \"${keywords}\"')}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
+    "loading" : m0,
+    "resultsFor" : m1,
+    "searchSign" : MessageLookupByLibrary.simpleMessage("Rechercher un signe")
+  };
+}

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -21,13 +21,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m0(suffix) => "Chargement${suffix}";
 
-  static m1(numResults, keywords) => "${Intl.plural(numResults, zero: 'Aucun résultats pour \"${keywords}\"', one: 'Résultat pour \"${keywords}\"', other: 'Résultats pour \"${keywords}\"')}";
+  static m1(numResults, keywords) =>
+      "${Intl.plural(numResults, zero: 'Aucun résultats pour \"${keywords}\"', one: 'Résultat pour \"${keywords}\"', other: 'Résultats pour \"${keywords}\"')}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
-    "loading" : m0,
-    "resultsFor" : m1,
-    "searchSign" : MessageLookupByLibrary.simpleMessage("Rechercher un signe")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "loading": m0,
+        "resultsFor": m1,
+        "searchSign": MessageLookupByLibrary.simpleMessage("Rechercher un signe")
+      };
 }

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -20,8 +20,8 @@ class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'messages';
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
-    "searchSign" : MessageLookupByLibrary.simpleMessage("Search a sign")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "searchSign": MessageLookupByLibrary.simpleMessage("Search a sign")
+      };
 }

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -1,0 +1,27 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a messages locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'messages';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "appName" : MessageLookupByLibrary.simpleMessage("Zéphyr"),
+    "searchSign" : MessageLookupByLibrary.simpleMessage("Search a sign")
+  };
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:zephyr/page/search_page.dart';
 
 void main() => runApp(MyApp());
@@ -13,23 +14,19 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: MyHomePage(title: "Zéphyr"),
+      localizationsDelegates: [GlobalMaterialLocalizations.delegate],
+      supportedLocales: [
+        const Locale("en"),
+        const Locale.fromSubtags(languageCode: "fr"),
+      ],
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
   final String title;
+
+  MyHomePage({Key key, this.title}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,10 +21,7 @@ class MyApp extends StatelessWidget {
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
-      supportedLocales: [
-        const Locale("en", ''),
-        const Locale("fr", ''),
-      ],
+      supportedLocales: supportedLocales,
     );
   }
 }
@@ -45,7 +42,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    print(MaterialLocalizations.of(context).nextMonthTooltip);
     return Scaffold(
       appBar: AppBar(
         title: Text(ZephyrLocalization.of(context).appName()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:zephyr/page/search_page.dart';
+import 'package:zephyr/zephyr_localization.dart';
 
 void main() => runApp(MyApp());
 
@@ -8,16 +9,21 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    String appName = "Zéphyr";
     return MaterialApp(
-      title: "Zéphyr",
+      title: appName,
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: "Zéphyr"),
-      localizationsDelegates: [GlobalMaterialLocalizations.delegate],
+      home: MyHomePage(title: appName),
+      localizationsDelegates: [
+        const ZephyrLocalizationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
       supportedLocales: [
-        const Locale("en"),
-        const Locale.fromSubtags(languageCode: "fr"),
+        const Locale("en", ''),
+        const Locale("fr", ''),
       ],
     );
   }
@@ -29,21 +35,20 @@ class MyHomePage extends StatefulWidget {
   MyHomePage({Key key, this.title}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState(title);
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  final String title;
+
+  _MyHomePageState(this.title) : super();
+
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    print(MaterialLocalizations.of(context).nextMonthTooltip);
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: Text(ZephyrLocalization.of(context).appName()),
       ),
       body: Center(
         child: Padding(
@@ -52,7 +57,7 @@ class _MyHomePageState extends State<MyHomePage> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               Text(
-                "Zéphyr",
+                title,
                 style: Theme.of(context).textTheme.headline4,
               ),
               SearchPage()

--- a/lib/page/result_page.dart
+++ b/lib/page/result_page.dart
@@ -3,6 +3,7 @@ import 'package:video_player/video_player.dart';
 import 'package:zephyr/model/sign.dart';
 import 'package:zephyr/service/dico_elix.dart';
 import 'package:zephyr/utils.dart';
+import 'package:zephyr/zephyr_localization.dart';
 
 class ResultPage extends StatefulWidget {
   final List<String> keywords;
@@ -89,7 +90,7 @@ class _ResultPageState extends State<ResultPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Result${plural(_signs?.length ?? 0)} for \"$joinedKeywords\""),
+        title: Text(_signs != null ? ZephyrLocalization.of(context).resultsFor(_signs.length, joinedKeywords) : ZephyrLocalization.of(context).loading()),
       ),
       body: ListView.builder(
         itemBuilder: (BuildContext context, int idx) {
@@ -152,7 +153,7 @@ class _ResultPageState extends State<ResultPage> {
             if (i == 0)
               return ListTile(
                 leading: CircularProgressIndicator(),
-                title: Text("Loading..."),
+                title: Text(ZephyrLocalization.of(context).loading()),
               );
             else
               return null;

--- a/lib/page/result_page.dart
+++ b/lib/page/result_page.dart
@@ -90,7 +90,9 @@ class _ResultPageState extends State<ResultPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(_signs != null ? ZephyrLocalization.of(context).resultsFor(_signs.length, joinedKeywords) : ZephyrLocalization.of(context).loading()),
+        title: Text(_signs != null
+            ? ZephyrLocalization.of(context).resultsFor(_signs.length, joinedKeywords)
+            : ZephyrLocalization.of(context).loading()),
       ),
       body: ListView.builder(
         itemBuilder: (BuildContext context, int idx) {

--- a/lib/page/search_page.dart
+++ b/lib/page/search_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:zephyr/page/result_page.dart';
+import 'package:zephyr/zephyr_localization.dart';
 
 /// Page that display the search bar and a search button.
 class SearchPage extends StatefulWidget {
@@ -50,7 +51,7 @@ class _SearchPageState extends State<SearchPage> {
               onSubmitted: null,
               decoration: InputDecoration(
                 border: new OutlineInputBorder(borderSide: new BorderSide(color: Colors.grey)),
-                labelText: "Search a sign",
+                labelText: ZephyrLocalization.of(context).searchSign(),
                 hintText: "Bonjour, au revoir, merci, ...", // TODO: Make dynamic list
               ),
               controller: _searchFieldController,

--- a/lib/page/search_page.dart
+++ b/lib/page/search_page.dart
@@ -25,7 +25,7 @@ class _SearchPageState extends State<SearchPage> {
   }
 
   /// Update the search button state according to the search field text emptiness.
-  /// 
+  ///
   /// If the search text field is empty, the search button is disabled, otherwise it is enable. The text is known
   /// through [_searchFieldController]. This function is designed to be used as a callback by
   /// [TextEditingController].
@@ -63,8 +63,8 @@ class _SearchPageState extends State<SearchPage> {
             onPressed: _enableSearchIcon
                 ? () {
                     Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => ResultPage([_searchFieldController.text.trim()])),
+                      context,
+                      MaterialPageRoute(builder: (context) => ResultPage([_searchFieldController.text.trim()])),
                     );
                   }
                 : null,

--- a/lib/page/search_page.dart
+++ b/lib/page/search_page.dart
@@ -58,7 +58,7 @@ class _SearchPageState extends State<SearchPage> {
           ),
           IconButton(
             icon: Icon(Icons.search),
-            tooltip: "Search",
+            tooltip: MaterialLocalizations.of(context).searchFieldLabel,
             onPressed: _enableSearchIcon
                 ? () {
                     Navigator.push(

--- a/lib/service/dico_elix.dart
+++ b/lib/service/dico_elix.dart
@@ -27,8 +27,7 @@ class DicoElix extends SignWebScrapper {
         }
 
         String videoUrl;
-        if (video != null && video.attributes.containsKey("src"))
-          videoUrl = video.attributes["src"];
+        if (video != null && video.attributes.containsKey("src")) videoUrl = video.attributes["src"];
 
         signs.add(Sign(
           title.text,

--- a/lib/zephyr_localization.dart
+++ b/lib/zephyr_localization.dart
@@ -1,0 +1,95 @@
+import 'package:diacritic/diacritic.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:zephyr/l10n/messages_all.dart';
+
+class ZephyrLocalization {
+  final String localeName;
+
+  ZephyrLocalization(this.localeName);
+
+  static ZephyrLocalization of(BuildContext context) {
+    return Localizations.of<ZephyrLocalization>(context, ZephyrLocalization);
+  }
+
+  static Future<ZephyrLocalization> load(Locale locale) async {
+    final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
+    final String localeName = Intl.canonicalizedLocale(name);
+    return initializeMessages(localeName).then((_) {
+      return ZephyrLocalization(localeName);
+    });
+  }
+
+  //#region STRINGS
+
+  String appName() {
+    return Intl.message(
+      "Zéphyr",
+      name: "appName",
+      desc: "The application name.",
+      locale: localeName,
+    );
+  }
+
+  String searchSign() {
+    return Intl.message(
+      "Search a sign",
+      name: "searchSign",
+      desc: "Indicates what the user must put in the search field.",
+      locale: localeName,
+    );
+  }
+
+  String loading([String suffix = "..."]) {
+    return Intl.message(
+      "Loading$suffix",
+      name: "loading",
+      args: [suffix],
+      desc: "Loading text.",
+      examples: const {"suffix": " program..."},
+      locale: localeName,
+    );
+  }
+
+  String resultsFor(int numResults, String keywords) {
+    return Intl.plural(
+      numResults,
+      zero: "No results for \"$keywords\"",
+      one: "Result for \"$keywords\"",
+      other: "Results for \"$keywords\"",
+      name: "resultsFor",
+      args: [numResults, keywords],
+      desc: "Title for the results page.",
+      examples: const {"numResults": 8, "keywords": "minute"},
+      locale: localeName,
+    );
+  }
+
+  //#endregion
+}
+
+class ZephyrLocalizationDelegate extends LocalizationsDelegate<ZephyrLocalization> {
+  const ZephyrLocalizationDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ["en", "fr"].contains(locale.languageCode);
+
+  @override
+  Future<ZephyrLocalization> load(Locale locale) => ZephyrLocalization.load(locale);
+
+  @override
+  bool shouldReload(ZephyrLocalizationDelegate old) => false;
+}
+
+/// Extension of [String] that add unitary string operations.
+extension StringExtension on String {
+  /// Return the capitalize version of the string.
+  String capitalize() {
+    return "${this[0].toUpperCase()}${this.substring(1)}";
+  }
+
+  /// Remove the accents from the string.
+  String removeAccents() {
+    return removeDiacritics(this);
+  }
+}

--- a/lib/zephyr_localization.dart
+++ b/lib/zephyr_localization.dart
@@ -3,6 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:zephyr/l10n/messages_all.dart';
 
+List<Locale> supportedLocales = [
+  const Locale("en", ''),
+  const Locale("fr", ''),
+  const Locale("es", ''),
+];
+
 class ZephyrLocalization {
   final String localeName;
 
@@ -72,7 +78,7 @@ class ZephyrLocalizationDelegate extends LocalizationsDelegate<ZephyrLocalizatio
   const ZephyrLocalizationDelegate();
 
   @override
-  bool isSupported(Locale locale) => ["en", "fr"].contains(locale.languageCode);
+  bool isSupported(Locale locale) => [for (Locale l in supportedLocales) l.languageCode].contains(locale.languageCode);
 
   @override
   Future<ZephyrLocalization> load(Locale locale) => ZephyrLocalization.load(locale);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: 0.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ description: Zephyr is a dictionary for LSF.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -23,6 +23,9 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  intl: 0.16.1
+  intl_translation:
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: 0.1.2
@@ -30,6 +33,7 @@ dependencies:
   html: 0.14.0+3
   http: 0.12.1
   video_player: 0.10.11+1
+  diacritic: 0.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* :globe_with_meridians:  :es: Add Spanish version
* :art: Format all code
	* Used `dartfmt`.
* :globe_with_meridians: Internationalized app
	* Added i18n and l10n.
	* Added a Makefile for the command to use i10n.
* :package: Add `flutter_localizations`
	* Make first i18n test using default strings. It works!
	* :memo: Added more content in the `README.md`.
* :memo: Add README and LICENSE files
* :sparkles: Play/pause the video
	* The videos can be played now! The tiles in the results list can be expanded.
	* Trimmed the keywords to suppress the trailing whitespace caused by the soft keyboards.
* :lipstick: Divider for items
	* Added dividers for items in the results list.
* :sparkles: Add result page with video thumbnails
	* Added a result page for the search, showing all the available videos, with a thumbnail.
	* :truck: Moved `search_page`.
	* :package: Added `video_player` dart dependency.
* :sparkles: Add dico elix web scrapper
	* The first web scrapper has been implemented.
	* Added `dartdoc_options.yaml` for `dartdoc` command.
	* Added the model `Sign`.
	* :package: Added dart packages `html` and `http`.
* :tada: First commit
	* Added a search page.
