### PR TITLE
😄 Loading messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DCK_CMP_UP=docker-compose up --remove-orphans
+DCK_CMP_UP=docker-compose up -d --remove-orphans
 
 .PHONY: all test
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -98,5 +98,107 @@
     "description": "Button saying \"Yes\".",
     "type": "text",
     "placeholders": {}
+  },
+  "loadingFingers": "Loading fingers 🖐...",
+  "@loadingFingers": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingItRock": "Making it rock 🤘...",
+  "@makingItRock": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "huggingContributors": "Hugging contributors 🤗...",
+  "@huggingContributors": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "connectingToElix": "Connecting to Elix 🤝...",
+  "@connectingToElix": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingEmojis": "Downloading emojis for facial expressions 🥳",
+  "@downloadingEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorOnlyCatsEmojis": "Error: Only cats emojis were found 😺",
+  "@errorOnlyCatsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catsEmojis": "🙀😸😻🐱",
+  "@catsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "addingMilkAnotherRoom": "Adding milk in another room 🥛...",
+  "@addingMilkAnotherRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catGoingToRoom": "🥛🐈🚪",
+  "@catGoingToRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "problemSolvedHumanEmojisRetrieved": "Problem solved: Human-emojis retrieved 🤓",
+  "@problemSolvedHumanEmojisRetrieved": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingSignPuns": "Downloading sign-puns 🙌...",
+  "@downloadingSignPuns": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "lameSignPunsDetected": "Lame puns detected... Removing them 👎...",
+  "@lameSignPunsDetected": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "balancingRightHandedLeftHanded": "Balancing right-handed and left-handed contributors 👐...",
+  "@balancingRightHandedLeftHanded": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingShadowPuppets": "Making shadow puppets... Just for fun 🤏",
+  "@makingShadowPuppets": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityF": "Setting accessibility 🧏‍♀️...",
+  "@settingAccessibilityF": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityM": "Setting accessibility 🧏‍♂️...",
+  "@settingAccessibilityM": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "cuttingNails": "Cutting nails 💅...",
+  "@cuttingNails": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -98,5 +98,107 @@
     "description": "Button saying \"Yes\".",
     "type": "text",
     "placeholders": {}
+  },
+  "loadingFingers": "Cargando los dedos 🖐...",
+  "@loadingFingers": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingItRock": "Ajuste del rock 🤘...",
+  "@makingItRock": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "huggingContributors": "Reconocimiento de los contribuyentes 🤗...",
+  "@huggingContributors": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "connectingToElix": "Conexión con Elix 🤝...",
+  "@connectingToElix": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingEmojis": "Descargando emojis para las expresiones faciales 🥳",
+  "@downloadingEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorOnlyCatsEmojis": "Error: Emojis de gatos encontrados 😺",
+  "@errorOnlyCatsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catsEmojis": "🙀😸😻🐱",
+  "@catsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "addingMilkAnotherRoom": "Añadiendo leche en otra habitación 🥛...",
+  "@addingMilkAnotherRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catGoingToRoom": "🥛🐈🚪",
+  "@catGoingToRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "problemSolvedHumanEmojisRetrieved": "Problema resuelto: Emojis humanoides descargados 🤓",
+  "@problemSolvedHumanEmojisRetrieved": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingSignPuns": "Descargar juegos de palabras firmadas 🙌...",
+  "@downloadingSignPuns": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "lameSignPunsDetected": "Se detectaron malos juegos de palabras... Eliminar 👎...",
+  "@lameSignPunsDetected": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "balancingRightHandedLeftHanded": "Equilibrio entre los contribuyentes diestros y zurdos 👐...",
+  "@balancingRightHandedLeftHanded": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingShadowPuppets": "Colocación de sombras chinas ... solo para jugar 🤏",
+  "@makingShadowPuppets": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityF": "Configuración de accesibilidad 🧏‍♀️...",
+  "@settingAccessibilityF": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityM": "Configuración de accesibilidad 🧏‍♂️...",
+  "@settingAccessibilityM": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "cuttingNails": "Manicura de uñas 💅...",
+  "@cuttingNails": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -98,5 +98,107 @@
     "description": "Button saying \"Yes\".",
     "type": "text",
     "placeholders": {}
+  },
+  "loadingFingers": "Chargement des doigts 🖐...",
+  "@loadingFingers": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingItRock": "Ajustement du rock 🤘...",
+  "@makingItRock": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "huggingContributors": "Remerciement des contributeurs 🤗...",
+  "@huggingContributors": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "connectingToElix": "Connexion à Elix 🤝...",
+  "@connectingToElix": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingEmojis": "Téléchargement des emojis pour les expressions faciales 🥳",
+  "@downloadingEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorOnlyCatsEmojis": "Erreur : Emojis de chats trouvés 😺",
+  "@errorOnlyCatsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catsEmojis": "🙀😸😻🐱",
+  "@catsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "addingMilkAnotherRoom": "Ajout de lait dans une autre pièce 🥛...",
+  "@addingMilkAnotherRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catGoingToRoom": "🥛🐈🚪",
+  "@catGoingToRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "problemSolvedHumanEmojisRetrieved": "Problème résolu : Emojis humanoïde téléchargés 🤓",
+  "@problemSolvedHumanEmojisRetrieved": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingSignPuns": "Téléchargement de jeux de mot signé 🙌...",
+  "@downloadingSignPuns": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "lameSignPunsDetected": "Jeux de mot pourris détectés... Suppression 👎...",
+  "@lameSignPunsDetected": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "balancingRightHandedLeftHanded": "Équilibrage des contributeurs droitiers et gaucher 👐...",
+  "@balancingRightHandedLeftHanded": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingShadowPuppets": "Mise en place d'ombres chinoises... Juste pour jouer 🤏",
+  "@makingShadowPuppets": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityF": "Paramétrage de l'accessibilité 🧏‍♀️...",
+  "@settingAccessibilityF": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityM": "Paramétrage de l'accessibilité 🧏‍♂️...",
+  "@settingAccessibilityM": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "cuttingNails": "Ongles en cours de manicures 💅...",
+  "@cuttingNails": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-07-26T18:11:22.704329",
+  "@@last_modified": "2020-07-27T15:29:32.422672",
   "appName": "Zéphyr",
   "@appName": {
     "description": "The application name.",
@@ -110,6 +110,108 @@
   "yes": "Yes",
   "@yes": {
     "description": "Button saying \"Yes\".",
+    "type": "text",
+    "placeholders": {}
+  },
+  "loadingFingers": "Loading fingers 🖐...",
+  "@loadingFingers": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingItRock": "Making it rock 🤘...",
+  "@makingItRock": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "huggingContributors": "Hugging contributors 🤗...",
+  "@huggingContributors": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "connectingToElix": "Connecting to Elix 🤝...",
+  "@connectingToElix": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingEmojis": "Downloading emojis for facial expressions 🥳",
+  "@downloadingEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorOnlyCatsEmojis": "Error: Only cats emojis were found 😺",
+  "@errorOnlyCatsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catsEmojis": "🙀😸😻🐱",
+  "@catsEmojis": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "addingMilkAnotherRoom": "Adding milk in another room 🥛...",
+  "@addingMilkAnotherRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "catGoingToRoom": "🥛🐈🚪",
+  "@catGoingToRoom": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "problemSolvedHumanEmojisRetrieved": "Problem solved: Human-emojis retrieved 🤓",
+  "@problemSolvedHumanEmojisRetrieved": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "downloadingSignPuns": "Downloading sign-puns 🙌...",
+  "@downloadingSignPuns": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "lameSignPunsDetected": "Lame puns detected... Removing them 👎...",
+  "@lameSignPunsDetected": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "balancingRightHandedLeftHanded": "Balancing right-handed and left-handed contributors 👐...",
+  "@balancingRightHandedLeftHanded": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "makingShadowPuppets": "Making shadow puppets... Just for fun 🤏",
+  "@makingShadowPuppets": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityF": "Setting accessibility 🧏‍♀️...",
+  "@settingAccessibilityF": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settingAccessibilityM": "Setting accessibility 🧏‍♂️...",
+  "@settingAccessibilityM": {
+    "description": "Loading message.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "cuttingNails": "Cutting nails 💅...",
+  "@cuttingNails": {
+    "description": "Loading message.",
     "type": "text",
     "placeholders": {}
   }

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -26,14 +26,32 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function>{
+        "settingAccessibilityM": MessageLookupByLibrary.simpleMessage("Setting accessibility 🧏‍♂️..."),
         "addToFavorites": MessageLookupByLibrary.simpleMessage("Add to favorites"),
+        "addingMilkAnotherRoom": MessageLookupByLibrary.simpleMessage("Adding milk in another room 🥛..."),
         "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "balancingRightHandedLeftHanded":
+            MessageLookupByLibrary.simpleMessage("Balancing right-handed and left-handed contributors 👐..."),
+        "catGoingToRoom": MessageLookupByLibrary.simpleMessage("🥛🐈🚪"),
+        "catsEmojis": MessageLookupByLibrary.simpleMessage("🙀😸😻🐱"),
         "clearTextField": MessageLookupByLibrary.simpleMessage("Clear text field"),
+        "connectingToElix": MessageLookupByLibrary.simpleMessage("Connecting to Elix 🤝..."),
+        "cuttingNails": MessageLookupByLibrary.simpleMessage("Cutting nails 💅..."),
+        "downloadingEmojis": MessageLookupByLibrary.simpleMessage("Downloading emojis for facial expressions 🥳"),
+        "downloadingSignPuns": MessageLookupByLibrary.simpleMessage("Downloading sign-puns 🙌..."),
+        "errorOnlyCatsEmojis": MessageLookupByLibrary.simpleMessage("Error: Only cats emojis were found 😺"),
         "favorite": MessageLookupByLibrary.simpleMessage("Favorite"),
+        "huggingContributors": MessageLookupByLibrary.simpleMessage("Hugging contributors 🤗..."),
+        "lameSignPunsDetected": MessageLookupByLibrary.simpleMessage("Lame puns detected... Removing them 👎..."),
         "loading": m0,
+        "loadingFingers": MessageLookupByLibrary.simpleMessage("Loading fingers 🖐..."),
+        "makingItRock": MessageLookupByLibrary.simpleMessage("Making it rock 🤘..."),
+        "makingShadowPuppets": MessageLookupByLibrary.simpleMessage("Making shadow puppets... Just for fun 🤏"),
         "no": MessageLookupByLibrary.simpleMessage("No"),
         "noSigns": MessageLookupByLibrary.simpleMessage("No signs"),
         "openDrawer": MessageLookupByLibrary.simpleMessage("Open drawer"),
+        "problemSolvedHumanEmojisRetrieved":
+            MessageLookupByLibrary.simpleMessage("Problem solved: Human-emojis retrieved 🤓"),
         "removeFromFavorites": MessageLookupByLibrary.simpleMessage("Remove from favorites"),
         "removeSearchHistory": MessageLookupByLibrary.simpleMessage("Remove search history"),
         "removeSearchHistoryConfirmation":
@@ -42,6 +60,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchButton": MessageLookupByLibrary.simpleMessage("Search button"),
         "searchSign": MessageLookupByLibrary.simpleMessage("Search a sign"),
         "searchSigns": MessageLookupByLibrary.simpleMessage("Search Signs"),
+        "settingAccessibilityF": MessageLookupByLibrary.simpleMessage("Setting accessibility 🧏‍♀️..."),
         "triggerVideoExplanation":
             MessageLookupByLibrary.simpleMessage("Click on the video to play it, and click it again to pause it."),
         "yes": MessageLookupByLibrary.simpleMessage("Yes")

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -26,14 +26,35 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function>{
+        "settingAccessibilityM": MessageLookupByLibrary.simpleMessage("Configuración de accesibilidad 🧏‍♂️..."),
         "addToFavorites": MessageLookupByLibrary.simpleMessage("Agregar a los favoritos"),
+        "addingMilkAnotherRoom": MessageLookupByLibrary.simpleMessage("Añadiendo leche en otra habitación 🥛..."),
         "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "balancingRightHandedLeftHanded":
+            MessageLookupByLibrary.simpleMessage("Equilibrio entre los contribuyentes diestros y zurdos 👐..."),
+        "catGoingToRoom": MessageLookupByLibrary.simpleMessage("🥛🐈🚪"),
+        "catsEmojis": MessageLookupByLibrary.simpleMessage("🙀😸😻🐱"),
         "clearTextField": MessageLookupByLibrary.simpleMessage("Borrar texto"),
+        "connectingToElix": MessageLookupByLibrary.simpleMessage("Conexión con Elix 🤝..."),
+        "cuttingNails": MessageLookupByLibrary.simpleMessage("Manicura de uñas 💅..."),
+        "downloadingEmojis":
+            MessageLookupByLibrary.simpleMessage("Descargando emojis para las expresiones faciales 🥳"),
+        "downloadingSignPuns": MessageLookupByLibrary.simpleMessage("Descargar juegos de palabras firmadas 🙌..."),
+        "errorOnlyCatsEmojis": MessageLookupByLibrary.simpleMessage("Error: Emojis de gatos encontrados 😺"),
         "favorite": MessageLookupByLibrary.simpleMessage("Favoritos"),
+        "huggingContributors": MessageLookupByLibrary.simpleMessage("Reconocimiento de los contribuyentes 🤗..."),
+        "lameSignPunsDetected":
+            MessageLookupByLibrary.simpleMessage("Se detectaron malos juegos de palabras... Eliminar 👎..."),
         "loading": m0,
+        "loadingFingers": MessageLookupByLibrary.simpleMessage("Cargando los dedos 🖐..."),
+        "makingItRock": MessageLookupByLibrary.simpleMessage("Ajuste del rock 🤘..."),
+        "makingShadowPuppets":
+            MessageLookupByLibrary.simpleMessage("Colocación de sombras chinas ... solo para jugar 🤏"),
         "no": MessageLookupByLibrary.simpleMessage("No"),
         "noSigns": MessageLookupByLibrary.simpleMessage("Sin signos"),
         "openDrawer": MessageLookupByLibrary.simpleMessage("Navegación abierta"),
+        "problemSolvedHumanEmojisRetrieved":
+            MessageLookupByLibrary.simpleMessage("Problema resuelto: Emojis humanoides descargados 🤓"),
         "removeFromFavorites": MessageLookupByLibrary.simpleMessage("Quitar de favoritos"),
         "removeSearchHistory": MessageLookupByLibrary.simpleMessage("Eliminar historial de búsqueda"),
         "removeSearchHistoryConfirmation":
@@ -42,6 +63,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchButton": MessageLookupByLibrary.simpleMessage("Botón de búsqueda"),
         "searchSign": MessageLookupByLibrary.simpleMessage("Busca una señal"),
         "searchSigns": MessageLookupByLibrary.simpleMessage("Busque Signos"),
+        "settingAccessibilityF": MessageLookupByLibrary.simpleMessage("Configuración de accesibilidad 🧏‍♀️..."),
         "triggerVideoExplanation": MessageLookupByLibrary.simpleMessage(
             "Haga clic en el video para reproducirlo y haga clic nuevamente para pausarlo."),
         "yes": MessageLookupByLibrary.simpleMessage("Si")

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -26,14 +26,35 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function>{
+        "settingAccessibilityM": MessageLookupByLibrary.simpleMessage("Paramétrage de l\'accessibilité 🧏‍♂️..."),
         "addToFavorites": MessageLookupByLibrary.simpleMessage("Ajouter aux favoris"),
+        "addingMilkAnotherRoom": MessageLookupByLibrary.simpleMessage("Ajout de lait dans une autre pièce 🥛..."),
         "appName": MessageLookupByLibrary.simpleMessage("Zéphyr"),
+        "balancingRightHandedLeftHanded":
+            MessageLookupByLibrary.simpleMessage("Équilibrage des contributeurs droitiers et gaucher 👐..."),
+        "catGoingToRoom": MessageLookupByLibrary.simpleMessage("🥛🐈🚪"),
+        "catsEmojis": MessageLookupByLibrary.simpleMessage("🙀😸😻🐱"),
         "clearTextField": MessageLookupByLibrary.simpleMessage("Effacer le texte"),
+        "connectingToElix": MessageLookupByLibrary.simpleMessage("Connexion à Elix 🤝..."),
+        "cuttingNails": MessageLookupByLibrary.simpleMessage("Ongles en cours de manicures 💅..."),
+        "downloadingEmojis":
+            MessageLookupByLibrary.simpleMessage("Téléchargement des emojis pour les expressions faciales 🥳"),
+        "downloadingSignPuns": MessageLookupByLibrary.simpleMessage("Téléchargement de jeux de mot signé 🙌..."),
+        "errorOnlyCatsEmojis": MessageLookupByLibrary.simpleMessage("Erreur : Emojis de chats trouvés 😺"),
         "favorite": MessageLookupByLibrary.simpleMessage("Favoris"),
+        "huggingContributors": MessageLookupByLibrary.simpleMessage("Remerciement des contributeurs 🤗..."),
+        "lameSignPunsDetected":
+            MessageLookupByLibrary.simpleMessage("Jeux de mot pourris détectés... Suppression 👎..."),
         "loading": m0,
+        "loadingFingers": MessageLookupByLibrary.simpleMessage("Chargement des doigts 🖐..."),
+        "makingItRock": MessageLookupByLibrary.simpleMessage("Ajustement du rock 🤘..."),
+        "makingShadowPuppets":
+            MessageLookupByLibrary.simpleMessage("Mise en place d\'ombres chinoises... Juste pour jouer 🤏"),
         "no": MessageLookupByLibrary.simpleMessage("Non"),
         "noSigns": MessageLookupByLibrary.simpleMessage("Aucun signes"),
         "openDrawer": MessageLookupByLibrary.simpleMessage("Ouvrir la navigation"),
+        "problemSolvedHumanEmojisRetrieved":
+            MessageLookupByLibrary.simpleMessage("Problème résolu : Emojis humanoïde téléchargés 🤓"),
         "removeFromFavorites": MessageLookupByLibrary.simpleMessage("Supprimer des favoris"),
         "removeSearchHistory": MessageLookupByLibrary.simpleMessage("Supprimer l\'historique de recherche"),
         "removeSearchHistoryConfirmation":
@@ -42,6 +63,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchButton": MessageLookupByLibrary.simpleMessage("Bouton de recherche"),
         "searchSign": MessageLookupByLibrary.simpleMessage("Rechercher un signe"),
         "searchSigns": MessageLookupByLibrary.simpleMessage("Rechercher des Signes"),
+        "settingAccessibilityF": MessageLookupByLibrary.simpleMessage("Paramétrage de l\'accessibilité 🧏‍♀️..."),
         "triggerVideoExplanation": MessageLookupByLibrary.simpleMessage(
             "Cliquez sur la video pour la jouer, et cliquez à nouveau pour la mettre en pause."),
         "yes": MessageLookupByLibrary.simpleMessage("Oui")

--- a/lib/page/loading_page.dart
+++ b/lib/page/loading_page.dart
@@ -31,12 +31,12 @@ class LoadingPage extends StatefulWidget {
     <String>["Setting accessibility 🧏‍♂️..."],
     <String>["Cutting nails 💅..."],
   ];
-  static const Duration defaultWaitingInterval = Duration(seconds: 5);
+  static const Duration defaultWaitingInterval = Duration(seconds: 4);
 
   final Duration waitingInterval;
 
   /// Default constructor for [LoadingPage]. You can customize the interval of time to wait between two messages
-  /// with [waitingInterval] (defaults to 5 seconds).
+  /// with [waitingInterval] (defaults to 4 seconds).
   LoadingPage({Key key, this.waitingInterval = defaultWaitingInterval}) : super(key: key);
 
   @override

--- a/lib/page/loading_page.dart
+++ b/lib/page/loading_page.dart
@@ -1,0 +1,142 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../zephyr_localization.dart';
+
+/// Widget that display a loading page, containing a [CircularProgressIndicator], a "Loading" text (translated) and a
+/// funny loading message that changes every now and then.
+class LoadingPage extends StatefulWidget {
+  final List<List<String>> messages = <List<String>>[
+    <String>["Loading fingers 🖐..."],
+    <String>["Making it rock 🤘..."],
+    <String>["Hugging contributors 🤗..."],
+    <String>["Connecting to Elix 🤝..."],
+    <String>[
+      "Downloading emojis for facial expressions 🥳",
+      "Error: Only cats emojis were found 😺",
+      "🙀😸😻🐱",
+      "Adding milk in another room 🥛...",
+      "🥛🐈🚪",
+      "Problem solved: Human-emojis retrieved 🤓",
+    ],
+    <String>[
+      "Downloading sign-puns 🙌...",
+      "Lame puns detected... Removing them 👎...",
+    ],
+    <String>["Balancing right-handed and left-handed contributors 👐..."],
+    <String>["Making shadow puppets... Just for fun 🤏"],
+    <String>["Setting accessibility 🧏‍♀️..."],
+    <String>["Setting accessibility 🧏‍♂️..."],
+    <String>["Cutting nails 💅..."],
+  ];
+  static const Duration defaultWaitingInterval = Duration(seconds: 5);
+
+  final Duration waitingInterval;
+
+  /// Default constructor for [LoadingPage]. You can customize the interval of time to wait between two messages
+  /// with [waitingInterval] (defaults to 5 seconds).
+  LoadingPage({Key key, this.waitingInterval = defaultWaitingInterval}) : super(key: key);
+
+  @override
+  _LoadingPageState createState() => _LoadingPageState();
+}
+
+/// State for [LoadingPage]. It manages the different messages through [nextMessage].
+class _LoadingPageState extends State<LoadingPage> {
+  /// [keepGeneratingMessage] keeps the [nextMessage] running while its value is `true`. If you want to stop
+  /// [nextMessage] from generating more message, turn it to `false`.
+  bool keepGeneratingMessage = true;
+
+  @override
+  void dispose() {
+    keepGeneratingMessage = false;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          CircularProgressIndicator(key: Key("loading_signs_results")),
+          SizedBox(height: 32),
+          Text(ZephyrLocalization.of(context).loading(), style: TextStyle(fontSize: 18)),
+          SizedBox(height: 32),
+          StreamBuilder<String>(
+            stream: nextMessage(),
+            builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+              String message = snapshot.data != null && snapshot.data.length > 0 ? snapshot.data : '';
+              return AnimatedSwitcher(
+                key: Key("loading_animated_switcher"),
+                duration: Duration(milliseconds: 200),
+                child: Text(
+                  message,
+                  key: Key("loading_message_${message.hashCode}"),
+                  style: TextStyle(color: Color.fromARGB(200, 255, 255, 255)),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Function that generate a continuous stream of message, until either [dispose] is called or [keepGeneratingMessage]
+  /// if `false`.
+  ///
+  /// The generated messages are selected randomly, but with an algorithm that prefer to select messages that was never
+  /// chose until now, rather than the messages that were already sent. When all possible messages have been sent, the
+  /// history list is automatically repeated so the function keeps generating messages. Certain messages have a
+  /// follow-up, which is respected by the function. You can customize the interval of time to wait between two messages
+  /// with [waitingInterval].
+  Stream<String> nextMessage({Duration waitingInterval}) async* {
+    if (waitingInterval == null) waitingInterval = widget.waitingInterval;
+
+    // History of indices. It is reset when all messages have been sent
+    List<int> indicesAlreadyYielded = <int>[];
+
+    // The current message and its follow-up (if any) being processed by the loop
+    List<String> messagesList = null;
+
+    // The index showing which message from [messagesList] were sent from the last iteration
+    int lastMessageIndex = -1;
+
+    // Placeholder containing the next message to yield
+    String nextMessage = null;
+
+    // Main loop generating messages
+    while (keepGeneratingMessage) {
+      // Check if there is a follow-up of the previous message
+      if (messagesList != null && lastMessageIndex >= 0 && lastMessageIndex + 1 < messagesList.length) {
+        nextMessage = messagesList[++lastMessageIndex];
+      } else {
+        // If all messages has been done, reset the counter
+        if (indicesAlreadyYielded.length == widget.messages.length) indicesAlreadyYielded.clear();
+
+        // Search for a next index
+        int nextIndex = -1;
+        do {
+          nextIndex = Random().nextInt(widget.messages.length);
+        } while (indicesAlreadyYielded.contains(nextIndex));
+
+        // Add the index to the history list
+        indicesAlreadyYielded.add(nextIndex);
+
+        messagesList = widget.messages[nextIndex];
+        lastMessageIndex = 0;
+
+        // Yield the message
+        nextMessage = messagesList[lastMessageIndex];
+      }
+      yield nextMessage;
+
+      await Future.delayed(waitingInterval);
+    }
+
+    if (kDebugMode) print("Finished nextMessage() stream.");
+  }
+}

--- a/lib/page/result_page.dart
+++ b/lib/page/result_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:zephyr/model/keywords.dart';
 import 'package:zephyr/model/sign.dart';
+import 'package:zephyr/page/loading_page.dart';
 import 'package:zephyr/page/sign_list_page.dart';
 import 'package:zephyr/service/dico_elix.dart';
 import 'package:zephyr/zephyr_localization.dart';
@@ -54,16 +55,7 @@ class _ResultPageState extends State<ResultPage> {
 
             return SignListPage(signs: signs);
           } else {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  CircularProgressIndicator(key: Key("loading_signs_results")),
-                  SizedBox(height: 32),
-                  Text(ZephyrLocalization.of(context).loading()),
-                ],
-              ),
-            );
+            return LoadingPage();
           }
         },
       ),

--- a/lib/page/result_page.dart
+++ b/lib/page/result_page.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:zephyr/model/keywords.dart';
 import 'package:zephyr/model/sign.dart';
-import 'package:zephyr/page/loading_page.dart';
 import 'package:zephyr/page/sign_list_page.dart';
 import 'package:zephyr/service/dico_elix.dart';
+import 'package:zephyr/service/loading_future_builder.dart';
 import 'package:zephyr/zephyr_localization.dart';
 
 class ResultPage extends StatefulWidget {
@@ -29,34 +29,31 @@ class _ResultPageState extends State<ResultPage> {
   Widget build(BuildContext context) {
     // Wait for the signs
     return Consumer<Keywords>(
-      builder: (context, keywords, _) => FutureBuilder(
+      builder: (context, keywords, _) => LoadingFutureBuilder(
         future: keywords.isEmpty ? Future.value(null) : _dicoElix.getSigns(keywords),
+        dataReady: (context, snapshot) => snapshot.connectionState == ConnectionState.done,
         builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            List<Sign> signs = snapshot.data;
+          List<Sign> signs = snapshot.data;
 
-            Widget noResults = Center(
-              child: Text(
-                ZephyrLocalization.of(context).resultsFor(0, keywords.value),
-                style: Theme.of(context).textTheme.headline4,
-              ),
-            );
+          Widget noResults = Center(
+            child: Text(
+              ZephyrLocalization.of(context).resultsFor(0, keywords.value),
+              style: Theme.of(context).textTheme.headline4,
+            ),
+          );
 
-            // If no keywords were given, display the default page or the "No Results" page if the former was not given
-            if (signs == null) {
-              if (widget.defaultPageBuilder != null)
-                return widget.defaultPageBuilder(context);
-              else
-                return noResults;
-            }
-
-            // If no results were returned
-            if (signs.isEmpty) return noResults;
-
-            return SignListPage(signs: signs);
-          } else {
-            return LoadingPage();
+          // If no keywords were given, display the default page or the "No Results" page if the former was not given
+          if (signs == null) {
+            if (widget.defaultPageBuilder != null)
+              return widget.defaultPageBuilder(context);
+            else
+              return noResults;
           }
+
+          // If no results were returned
+          if (signs.isEmpty) return noResults;
+
+          return SignListPage(signs: signs);
         },
       ),
     );

--- a/lib/service/loading_future_builder.dart
+++ b/lib/service/loading_future_builder.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+import 'package:zephyr/page/loading_page.dart';
+
+typedef bool SnapshotReadiness<T>(BuildContext context, AsyncSnapshot<T> snapshot);
+
+/// [LoadingFutureBuilder] is a [FutureBuilder] that build the given [builder] only if the data is ready. If it is not,
+/// the loading page will be shown instead.
+class LoadingFutureBuilder<T> extends StatelessWidget {
+  final Future<T> future;
+  final T initialData;
+  final SnapshotReadiness<T> dataReady;
+  final AsyncWidgetBuilder<T> builder;
+
+  /// Constructor for [LoadingFutureBuilder]. For description of [future], [initialData] and [builder], please see the
+  /// [FutureBuilder] documentation. [dataReady] is a callback that returns `true` if the data is ready and [builder]
+  /// should be called, or `false` to display the loading page (see [LoadingPage]).
+  LoadingFutureBuilder({Key key, this.future, this.initialData, this.dataReady, @required this.builder})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: future,
+      initialData: initialData,
+      builder: (context, snapshot) {
+        if (dataReady != null && !dataReady(context, snapshot) || dataReady == null && !snapshot.hasData)
+          return LoadingPage();
+        else
+          return this.builder(context, snapshot);
+      },
+    );
+  }
+}

--- a/lib/zephyr_localization.dart
+++ b/lib/zephyr_localization.dart
@@ -189,6 +189,190 @@ class ZephyrLocalization {
     );
   }
 
+  //region LOADING MESSAGES
+
+  String loadingFingers() {
+    return Intl.message(
+      "Loading fingers 🖐...",
+      name: "loadingFingers",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String makingItRock() {
+    return Intl.message(
+      "Making it rock 🤘...",
+      name: "makingItRock",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String huggingContributors() {
+    return Intl.message(
+      "Hugging contributors 🤗...",
+      name: "huggingContributors",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String connectingToElix() {
+    return Intl.message(
+      "Connecting to Elix 🤝...",
+      name: "connectingToElix",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String downloadingEmojis() {
+    return Intl.message(
+      "Downloading emojis for facial expressions 🥳",
+      name: "downloadingEmojis",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String errorOnlyCatsEmojis() {
+    return Intl.message(
+      "Error: Only cats emojis were found 😺",
+      name: "errorOnlyCatsEmojis",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String catsEmojis() {
+    return Intl.message(
+      "🙀😸😻🐱",
+      name: "catsEmojis",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String addingMilkAnotherRoom() {
+    return Intl.message(
+      "Adding milk in another room 🥛...",
+      name: "addingMilkAnotherRoom",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String catGoingToRoom() {
+    return Intl.message(
+      "🥛🐈🚪",
+      name: "catGoingToRoom",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String problemSolvedHumanEmojisRetrieved() {
+    return Intl.message(
+      "Problem solved: Human-emojis retrieved 🤓",
+      name: "problemSolvedHumanEmojisRetrieved",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  List<String> emojisConversation() => <String>[
+        downloadingEmojis(),
+        errorOnlyCatsEmojis(),
+        catsEmojis(),
+        addingMilkAnotherRoom(),
+        catGoingToRoom(),
+        problemSolvedHumanEmojisRetrieved(),
+      ];
+
+  String downloadingSignPuns() {
+    return Intl.message(
+      "Downloading sign-puns 🙌...",
+      name: "downloadingSignPuns",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String lameSignPunsDetected() {
+    return Intl.message(
+      "Lame puns detected... Removing them 👎...",
+      name: "lameSignPunsDetected",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  List<String> signPunsConversation() => <String>[downloadingSignPuns(), lameSignPunsDetected()];
+
+  String balancingRightHandedLeftHanded() {
+    return Intl.message(
+      "Balancing right-handed and left-handed contributors 👐...",
+      name: "balancingRightHandedLeftHanded",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String makingShadowPuppets() {
+    return Intl.message(
+      "Making shadow puppets... Just for fun 🤏",
+      name: "makingShadowPuppets",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String settingAccessibilityF() {
+    return Intl.message(
+      "Setting accessibility 🧏‍♀️...",
+      name: "settingAccessibilityF",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String settingAccessibilityM() {
+    return Intl.message(
+      "Setting accessibility 🧏‍♂️...",
+      name: "settingAccessibilityM",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  String cuttingNails() {
+    return Intl.message(
+      "Cutting nails 💅...",
+      name: "cuttingNails",
+      desc: "Loading message.",
+      locale: localeName,
+    );
+  }
+
+  List<List<String>> allLoadingMessages() {
+    return <List<String>>[
+      <String>[loadingFingers()],
+      <String>[makingItRock()],
+      <String>[huggingContributors()],
+      <String>[connectingToElix()],
+      emojisConversation(),
+      signPunsConversation(),
+      <String>[balancingRightHandedLeftHanded()],
+      <String>[makingShadowPuppets()],
+      <String>[settingAccessibilityF()],
+      <String>[settingAccessibilityM()],
+      <String>[cuttingNails()],
+    ];
+  }
+
+  //endregion
+
   //#endregion
 }
 


### PR DESCRIPTION
Fixed #13.

* :lipstick: Loading messages appear 1.5 seconds after loading page
	* :zap: Optimized the function to select next loading message.
* :globe_with_meridians: Translate loading messages
* :art: Add `LoadingFutureBuilder`, a `FutureBuilder` with a built-in loading page
* :sparkles: Add `LoadingPage`
	* The loading page has been created and works just fine. The messages are displayed during 5 seconds, before being changed to the next (either new random message or a follow-up) with an animation.
